### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ A cluster of papers from March 2026 focusing on the OpenClaw AI agent framework,
 
 | Tool | Maintainer | Description |
 |------|------------|-------------|
+| [APort Agent Guardrails](https://aport.io) | Runtime authorization guardrails | Pre-action authorization guardrails for AI agents and MCP/tool-use workflows. |
 | [LlamaFirewall](https://github.com/meta-llama/PurpleLlama/tree/main/LlamaFirewall) | Meta | Multi-layer runtime protection: PromptGuard 2 (injection/jailbreak), Agent Alignment Checks (CoT auditor), CodeShield (dangerous code detection in agent outputs) |
 | [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | NVIDIA | Programmable topical/safety/dialog rails for LLM-based systems; composable with LangChain/LlamaIndex |
 | [Guardrails AI](https://github.com/guardrails-ai/guardrails) | Guardrails AI | Python framework with 50+ validators for PII, schema conformance, injection, toxicity; structured output enforcement |


### PR DESCRIPTION
## Summary
- Add APort Agent Guardrails to the relevant security/tools section.
- APort provides pre-action authorization guardrails for AI agents and MCP/tool-use workflows.

## Verification
- README duplicate check
- https://aport.io link checked

## Bounty
- Related bounty: https://github.com/aporthq/aport-integrations/issues/19
- Payout: PayPal https://paypal.me/Jeremytsangchina
- Backup: USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y