### PR TITLE
feat: add TWZRD Agent Intel to Defensive Tools — on-chain agent identity verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,12 @@ A cluster of papers from March 2026 focusing on the OpenClaw AI agent framework,
 | [OpenPromptInjection](https://github.com/liu00222/Open-Prompt-Injection) | Benchmark for prompt injection attacks and defenses across diverse agent scenarios |
 | [Damn Vulnerable MCP Server](https://github.com/harishsg993010/damn-vulnerable-MCP-server) | Deliberately vulnerable MCP server for security education and testing |
 
+### Agent Identity & Trust Verification
+
+| Tool | Maintainer | Description |
+|------|------------|-------------|
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | TWZRD | On-chain trust scoring for AI agents on Solana. `score_agent(wallet)` returns a behavioral trust score; `preflight_check(wallet)` gives a go/no-go before agent-to-agent transactions. Free streamable-HTTP MCP server — no API key required. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` |
+
 ### Observability & Tracing
 
 | Tool | Description |


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** under a new **Agent Identity & Trust Verification** subsection in Defensive Tools.

TWZRD addresses the identity layer that's missing from most defensive stacks: before an autonomous agent sends a payment or executes an action on behalf of another agent's wallet, what's its on-chain trust history? This is particularly relevant given incidents like the procurement agent memory poisoning and A2A session smuggling attacks documented in this list — a trust verification preflight call could surface anomalous wallets before damage is done.

**Tools provided:**
- `score_agent(wallet)` — on-chain behavioral trust score
- `preflight_check(wallet)` — binary go/no-go for agent-to-agent interactions
- `get_trust_receipt(wallet)` — paid x402 trust receipt (auditable proof)

**Free MCP (streamable-http, no auth):**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Live endpoint: https://intel.twzrd.xyz